### PR TITLE
Fix frontend API routing for Kubernetes deployment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,63 +2,61 @@
 
 ## Nx Monorepo Migration Agents & Automation
 
-This document describes the automated agents, scripts, and CI/CD bots involved in the Nx monorepo setup and maintenance for this repository.
+This document describes the automated agents, scripts, and CI/CD bots involved
+in the Nx monorepo setup and maintenance for this repository.
 
 ---
 
 ## 1. Nx CLI & Nx Cloud
 
-- **Purpose:** Orchestrates builds, tests, linting, and affected commands across all apps and libraries in the monorepo.
-- **Key Commands:**
-  - `npx nx build <project>`
-  - `npx nx test <project>`
-  - `npx nx lint <project>`
-  - `npx nx affected:*`
-- **Automation:** Used in all build scripts and CI/CD pipelines.
+- **Purpose:** Orchestrates builds, tests, linting, and affected commands across
+  all apps and libraries in the monorepo. - **Key Commands:** - `npx nx build
+  <project>` - `npx nx test <project>` - `npx nx lint <project>` - `npx nx
+  affected:*` - **Automation:** Used in all build scripts and CI/CD pipelines.
 
 ## 2. CI/CD Agents
 
 ### GitHub Actions
 
-- **Workflow:** `.github/workflows/docker-image.yml`
-- **Purpose:** Builds and pushes Docker images for frontend and backend on push/PR/Release.
-- **Key Steps:**
-  - Build Docker images using Nx outputs
-  - Push to Docker Hub
+- **Workflow:** `.github/workflows/docker-image.yml` - **Purpose:** Builds and
+  pushes Docker images for frontend and backend on push/PR/Release. - **Key
+  Steps:** - Build Docker images using Nx outputs - Push to Docker Hub
 
 ### CircleCI
 
-- **Workflow:** `.circleci/config.yml`
-- **Purpose:** Runs Nx build, test, and lint for all projects. Uploads coverage to Coveralls and Codacy.
-- **Key Steps:**
-  - `npm ci --legacy-peer-deps`
-  - `npx nx build/test/lint <project>`
-  - Coverage upload
+- **Workflow:** `.circleci/config.yml` - **Purpose:** Runs Nx build, test, and
+  lint for all projects. Uploads coverage to Coveralls and Codacy. - **Key
+  Steps:** - `npm ci --legacy-peer-deps` - `npx nx build/test/lint <project>` -
+  Coverage upload
 
 ### AppVeyor
 
-- **Config:** `appveyor.yml`
-- **Purpose:** Windows CI for Nx monorepo. Runs build/test/lint using PowerShell.
+- **Config:** `appveyor.yml` - **Purpose:** Windows CI for Nx monorepo. Runs
+  build/test/lint using PowerShell.
 
 ## 3. Build & Maintenance Scripts
 
-- **rebuild.sh / rebuild.cmd / rebuild.ps1**
-  - Unified scripts for building, testing, and linting all apps using Nx CLI.
-  - Accepts parameters for backend/frontend/all.
+- **rebuild.sh / rebuild.cmd / rebuild.ps1** - Unified scripts for building,
+  testing, and linting all apps using Nx CLI. - Accepts parameters for
+  backend/frontend/all.
 
 ## 4. Nx Agents (Copilot/Automation)
 
-- **Copilot/AI Agents:**
-  - Used for migration, code refactoring, and CI/CD updates.
-  - Ensures dependency alignment, .gitignore management, and monorepo best practices.
+- **Copilot/AI Agents:** - Used for migration, code refactoring, and CI/CD
+  updates. - Ensures dependency alignment, .gitignore management, and monorepo
+  best practices.
 
 ## 5. Source Control Automation
 
-- **.gitignore:** Now includes `.nx` to prevent workspace state from being tracked.
-- **Automated Cleanup:**
-  - Run `git rm -r --cached .nx` after adding to .gitignore to remove from history.
+- **.gitignore:** Now includes `.nx` to prevent workspace state from being
+  tracked. - **Automated Cleanup:** - Run `git rm -r --cached .nx` after adding
+  to .gitignore to remove from history.
 
 ---
 
 ## Summary
-All automation and agents are now aligned for Nx 21 + Angular 21 monorepo development. CI/CD, build scripts, and source control ignore rules are up to date. For any new automation, update this file to document the agent's role and configuration.
+
+All automation and agents are now aligned for Nx 21 + Angular 21 monorepo
+development. CI/CD, build scripts, and source control ignore rules are up to
+date. For any new automation, update this file to document the agent's role and
+configuration.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,37 @@
 
-|  Build | Coverage  | Code Analysis   | SCA | Publish  |
-|---|---|---|---|---|
-|[![CircleCI](https://dl.circleci.com/status-badge/img/gh/tuanicom/incap/tree/master.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/tuanicom/incap/tree/master)   | [![Coverage Status](https://coveralls.io/repos/github/tuanicom/incap/badge.svg?branch=master)](https://coveralls.io/github/tuanicom/incap?branch=master)  |  [![Sonar Status](https://sonarcloud.io/api/project_badges/measure?project=tuanicom_incap&metric=alert_status)](https://sonarcloud.io/dashboard?id=tuanicom_incap) | [![Known Vulnerabilities](https://snyk.io/test/github/tuanicom/incap/badge.svg?targetFile=backend%2Fpackage.json)](https://snyk.io/test/github/tuanicom/incap?targetFile=backend%2Fpackage.json) |[![Docker Image CI](https://github.com/tuanicom/incap/actions/workflows/docker-image.yml/badge.svg)](https://github.com/tuanicom/incap/actions/workflows/docker-image.yml) |
-|[![Build status](https://ci.appveyor.com/api/projects/status/x9dtpjle2v6afiwf?svg=true)](https://ci.appveyor.com/project/tuanicom/incap)   | [![codecov](https://codecov.io/gh/tuanicom/incap/branch/master/graph/badge.svg)](https://codecov.io/gh/tuanicom/incap)  |  [![Codacy Badge](https://app.codacy.com/project/badge/Grade/0f7609d8534e4ca89dbda6af634166a9)](https://www.codacy.com/gh/tuanicom/incap/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=tuanicom/incap&amp;utm_campaign=Badge_Grade) | [![Known Vulnerabilities](https://snyk.io/test/github/tuanicom/incap/badge.svg?targetFile=frontend%2Fpackage.json)](https://snyk.io/test/github/tuanicom/incap?targetFile=frontend%2Fpackage.json) | [![pages-build-deployment](https://github.com/tuanicom/incap/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/tuanicom/incap/actions/workflows/pages/pages-build-deployment) |
-
 # incap
 
-This is just a personal test project. Anyway, if you want to fork it, feel free to do it (just let me know your goal)
+## Project Status
+
+- [CircleCI build status](https://dl.circleci.com/status-badge/redirect/gh/tuanicom/incap/tree/master)
+- [AppVeyor build status](https://ci.appveyor.com/project/tuanicom/incap)
+- [Coveralls coverage](https://coveralls.io/github/tuanicom/incap?branch=master)
+- [Codecov coverage](https://codecov.io/gh/tuanicom/incap)
+- [SonarCloud quality gate](https://sonarcloud.io/dashboard?id=tuanicom_incap)
+- [Codacy grade](https://www.codacy.com/gh/tuanicom/incap/dashboard)
+- [Snyk backend scan](https://snyk.io/test/github/tuanicom/incap?targetFile=backend%2Fpackage.json)
+- [Snyk frontend scan](https://snyk.io/test/github/tuanicom/incap?targetFile=frontend%2Fpackage.json)
+- [Docker image workflow](https://github.com/tuanicom/incap/actions/workflows/docker-image.yml)
+- [Pages deployment workflow](https://github.com/tuanicom/incap/actions/workflows/pages/pages-build-deployment)
+
+This is just a personal test project. Anyway, if you want to fork it, feel free
+to do it (just let me know your goal)
 
 ## Purpose
-This is a test project for me to be able to test a few technologies I want to get skilled on:
-*   MEAN stack (with Typescript) 
-*   PrimeNG with Tailwind
-*   Nx
-*   Micro-services
-*   Docker/Kubernetes
+
+This is a test project for me to be able to test a few technologies I want to
+get skilled on:
+
+- MEAN stack (with Typescript)
+- PrimeNG with Tailwind
+- Nx
+- Micro-services
+- Docker/Kubernetes
 
 ## Presentation of the application
-This application is based on a old website we wrote in PHP long time ago with a friend. 
-This site was a kind of collaborative blog where community people (our friends) wrote some articles on various topics, sorted into categories, on which we could add comments. 
-It has been killed by the arrival of Facebook (sad, right?)
+
+This application is based on a old website we wrote in PHP long time ago with a
+friend. This site was a kind of collaborative blog where community people (our
+friends) wrote some articles on various topics, sorted into categories, on which
+we could add comments. It has been killed by the arrival of Facebook (sad,
+right?)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,12 @@
 
 ## Supported Versions
 
-| Version | Supported          |
+| Version | Supported |
+
 | ------- | ------------------ |
-| 1.0.x   | :white_check_mark: |
+
+| 1.0.x | :white_check_mark: |
 
 ## Reporting a Vulnerability
 
-https://github.com/tuanicom/incap/issues
+<https://github.com/tuanicom/incap/issues>

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -16,8 +16,9 @@ COPY apps/frontend/nginx.conf /src/nginx.conf
 COPY --from=builder /usr/src/app/dist/apps/frontend/browser/ /usr/share/nginx/html/
 
 EXPOSE 8080
-ENV CATEGORIES_API_URL=http://localhost/api/categories
-ENV USERS_API_URL=http://localhost/api/users
-ENV ARTICLES_API_URL=http://localhost/api/articles
+ENV CATEGORIES_API_URL=http://incap-backend:4000/categories
+ENV USERS_API_URL=http://incap-backend:4000/users
+ENV ARTICLES_API_URL=http://incap-backend:4000/articles
+ENV COMMENTS_API_URL=http://incap-backend:4000/comments
 
-CMD ["/bin/sh", "-c", "envsubst '$CATEGORIES_API_URL,$USERS_API_URL,$ARTICLES_API_URL' < /src/nginx.conf > /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"]
+CMD ["/bin/sh", "-c", "envsubst '$CATEGORIES_API_URL,$USERS_API_URL,$ARTICLES_API_URL,$COMMENTS_API_URL' < /src/nginx.conf > /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"]

--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -51,5 +51,15 @@ http {
           proxy_set_header  X-NginX-Proxy true;
           proxy_redirect    off;
         }
+
+        location /api/comments {
+          proxy_pass        ${COMMENTS_API_URL};
+          proxy_set_header  Host $host;
+          proxy_set_header  X-Real-IP $remote_addr;
+          proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header  Host $http_host;
+          proxy_set_header  X-NginX-Proxy true;
+          proxy_redirect    off;
+        }
     }
 }

--- a/apps/frontend/src/app/app.settings.spec.ts
+++ b/apps/frontend/src/app/app.settings.spec.ts
@@ -9,7 +9,8 @@ describe('AppSettings', () => {
     const appSettings: AppSettings = {
         categoriesApiUrl: '',
         usersApiUrl: '',
-        articlesApiUrl: ''
+        articlesApiUrl: '',
+        commentsApiUrl: ''
     };
     let appSettingsService: AppSettingsService = new AppSettingsService();
     let appSettingsHttpService: AppSettingsHttpService;
@@ -22,6 +23,8 @@ describe('AppSettings', () => {
         };
         appSettings.categoriesApiUrl = 'http://localhost:4000/categories';
         appSettings.usersApiUrl = 'http://localhost:4000/users';
+        appSettings.articlesApiUrl = 'http://localhost:4000/articles';
+        appSettings.commentsApiUrl = 'http://localhost:4000/comments';
 
         await TestBed.configureTestingModule({
             imports: [],

--- a/apps/frontend/src/app/app.settings.ts
+++ b/apps/frontend/src/app/app.settings.ts
@@ -5,6 +5,7 @@ export interface AppSettings {
   categoriesApiUrl: string;
   usersApiUrl: string;
   articlesApiUrl: string;
+  commentsApiUrl: string;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -12,7 +13,8 @@ export class AppSettingsService {
   public settings: AppSettings = {
     categoriesApiUrl: '',
     usersApiUrl: '',
-    articlesApiUrl: ''
+    articlesApiUrl: '',
+    commentsApiUrl: ''
   };
 }
 

--- a/apps/frontend/src/app/comments/comment.service.spec.ts
+++ b/apps/frontend/src/app/comments/comment.service.spec.ts
@@ -22,7 +22,7 @@ describe('CommentService', () => {
       providers: [
         CommentService,
         { provide: HttpClient, useValue: httpClientSpy },
-        { provide: AppSettingsService, useValue: { settings: { articlesApiUrl: 'http://localhost:4000/articles' } } }
+        { provide: AppSettingsService, useValue: { settings: { articlesApiUrl: 'http://localhost:4000/articles', commentsApiUrl: 'http://localhost:4000/comments' } } }
       ]
     }).compileComponents();
   });
@@ -74,7 +74,7 @@ describe('CommentService', () => {
     it('should call put on /comments/:id', () => {
       service.update('1', { text: 'u' });
       expect(httpClientSpy.put).toHaveBeenCalled();
-      expect(vi.mocked(httpClientSpy.put).mock.calls[0][0]).toBe('/comments/1');
+      expect(vi.mocked(httpClientSpy.put).mock.calls[0][0]).toBe('http://localhost:4000/comments/1');
     });
   });
 
@@ -87,7 +87,7 @@ describe('CommentService', () => {
     it('should call delete on /comments/:id', () => {
       service.delete('1');
       expect(httpClientSpy.delete).toHaveBeenCalled();
-      expect(vi.mocked(httpClientSpy.delete).mock.calls[0][0]).toBe('/comments/1');
+      expect(vi.mocked(httpClientSpy.delete).mock.calls[0][0]).toBe('http://localhost:4000/comments/1');
     });
   });
 });

--- a/apps/frontend/src/app/comments/comment.service.ts
+++ b/apps/frontend/src/app/comments/comment.service.ts
@@ -13,6 +13,10 @@ export class CommentService {
     return this.appSettings.settings.articlesApiUrl;
   }
 
+  private get commentsApi(): string {
+    return this.appSettings.settings.commentsApiUrl;
+  }
+
   public listForArticle(articleId: string): Observable<Comment[]> {
     return this.http.get<Comment[]>(`${this.articlesApi}/${articleId}/comments`);
   }
@@ -22,10 +26,10 @@ export class CommentService {
   }
 
   public update(id: string, payload: Partial<Comment>): Observable<Comment> {
-    return this.http.put<Comment>(`/comments/${id}`, payload);
+    return this.http.put<Comment>(`${this.commentsApi}/${id}`, payload);
   }
 
   public delete(id: string): Observable<any> {
-    return this.http.delete(`/comments/${id}`);
+    return this.http.delete(`${this.commentsApi}/${id}`);
   }
 }

--- a/apps/frontend/src/assets/settings.json
+++ b/apps/frontend/src/assets/settings.json
@@ -1,5 +1,6 @@
 {
   "categoriesApiUrl":"/api/categories",
   "usersApiUrl":"/api/users",
-  "articlesApiUrl":"/api/articles"
+  "articlesApiUrl":"/api/articles",
+  "commentsApiUrl":"/api/comments"
 }

--- a/deploy/backend-deployment.yaml
+++ b/deploy/backend-deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     io.kompose.service: incap-backend
   name: incap-backend
+  namespace: incap
 spec:
   replicas: 1
   strategy: {}

--- a/deploy/backend-deployment.yaml
+++ b/deploy/backend-deployment.yaml
@@ -1,20 +1,22 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
     kompose.cmd: kompose -f docker-compose.yml convert
     kompose.version: 1.16.0 (0c01309)
-  creationTimestamp: null
   labels:
     io.kompose.service: incap-backend
   name: incap-backend
   namespace: incap
 spec:
   replicas: 1
-  strategy: {}
+  selector:
+    matchLabels:
+      io.kompose.service: incap-backend
+  strategy:
+    type: RollingUpdate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.service: incap-backend
     spec:
@@ -23,7 +25,18 @@ spec:
             - name: MONGO_DB_URL
               value: mongodb:27017
           image: tuanicom/incap-backend
+          imagePullPolicy: Always
           name: incap-backend
+          livenessProbe:
+            tcpSocket:
+              port: 4000
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          readinessProbe:
+            tcpSocket:
+              port: 4000
+            initialDelaySeconds: 10
+            periodSeconds: 10
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
@@ -34,4 +47,3 @@ spec:
             - containerPort: 4000
           resources: {}
       restartPolicy: Always
-status: {}

--- a/deploy/backend-service.yaml
+++ b/deploy/backend-service.yaml
@@ -7,14 +7,16 @@ metadata:
   creationTimestamp: null
   labels:
     io.kompose.service: incap-backend
+    name: incap-backend
   name: incap-backend
+  namespace: incap
 spec:
-  type: NodePort
+  type: LoadBalancer
   ports:
-  - name: "4000"
+  - name: "incap-backend"
     port: 4000
     targetPort: 4000
-    nodePort: 30400
+    protocol: TCP
   selector:
     io.kompose.service: incap-backend
 status:

--- a/deploy/backend-service.yaml
+++ b/deploy/backend-service.yaml
@@ -4,14 +4,13 @@ metadata:
   annotations:
     kompose.cmd: kompose -f docker-compose.yml convert
     kompose.version: 1.16.0 (0c01309)
-  creationTimestamp: null
   labels:
     io.kompose.service: incap-backend
     name: incap-backend
   name: incap-backend
   namespace: incap
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
   - name: "incap-backend"
     port: 4000
@@ -19,5 +18,3 @@ spec:
     protocol: TCP
   selector:
     io.kompose.service: incap-backend
-status:
-  loadBalancer: {}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -7,9 +7,12 @@ services:
     ports:
       - "8080:8080" # specify port forewarding
     environment:
-      CATEGORIES_API_URL: http://localhost:4000/categories
+      CATEGORIES_API_URL: http://incap-backend:4000/categories
+      USERS_API_URL: http://incap-backend:4000/users
+      ARTICLES_API_URL: http://incap-backend:4000/articles
+      COMMENTS_API_URL: http://incap-backend:4000/comments
     depends_on:
-      - backend
+      - incap-backend
 
   incap-backend: #name of the second service
     image: tuanicom/incap-backend

--- a/deploy/frontend-deployment.yaml
+++ b/deploy/frontend-deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     io.kompose.service: incap-frontend
   name: incap-frontend
+  namespace: incap
 spec:
   replicas: 1
   strategy: {}

--- a/deploy/frontend-deployment.yaml
+++ b/deploy/frontend-deployment.yaml
@@ -21,7 +21,13 @@ spec:
       containers:
         - env:
             - name: CATEGORIES_API_URL
-              value: http://localhost:4000
+              value: http://incap-backend:4000/categories
+            - name: USERS_API_URL
+              value: http://incap-backend:4000/users
+            - name: ARTICLES_API_URL
+              value: http://incap-backend:4000/articles
+            - name: COMMENTS_API_URL
+              value: http://incap-backend:4000/comments
           image: tuanicom/incap-frontend
           name: incap-frontend
           securityContext:

--- a/deploy/frontend-deployment.yaml
+++ b/deploy/frontend-deployment.yaml
@@ -1,20 +1,22 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
     kompose.cmd: kompose -f docker-compose.yml convert
     kompose.version: 1.16.0 (0c01309)
-  creationTimestamp: null
   labels:
     io.kompose.service: incap-frontend
   name: incap-frontend
   namespace: incap
 spec:
   replicas: 1
-  strategy: {}
+  selector:
+    matchLabels:
+      io.kompose.service: incap-frontend
+  strategy:
+    type: RollingUpdate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.service: incap-frontend
     spec:
@@ -29,7 +31,20 @@ spec:
             - name: COMMENTS_API_URL
               value: http://incap-backend:4000/comments
           image: tuanicom/incap-frontend
+          imagePullPolicy: Always
           name: incap-frontend
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
@@ -40,4 +55,3 @@ spec:
             - containerPort: 8080
           resources: {}
       restartPolicy: Always
-status: {}

--- a/deploy/frontend-service.yaml
+++ b/deploy/frontend-service.yaml
@@ -6,15 +6,17 @@ metadata:
     kompose.version: 1.16.0 (0c01309)
   creationTimestamp: null
   labels:
+    name: incap-frontend
     io.kompose.service: incap-frontend
   name: incap-frontend
+  namespace: incap
 spec:
-  type: NodePort
+  type: LoadBalancer
   ports:
-  - name: "8080"
-    port: 8080
+  - name: "incap-frontend"
+    port: 80
     targetPort: 8080
-    nodePort: 30080
+    protocol: TCP
   selector:
     io.kompose.service: incap-frontend
 status:

--- a/deploy/mongodb-deployment.yaml
+++ b/deploy/mongodb-deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     io.kompose.service: mongodb
   name: mongodb
+  namespace: incap
 spec:
   replicas: 1
   strategy: {}

--- a/deploy/mongodb-deployment.yaml
+++ b/deploy/mongodb-deployment.yaml
@@ -1,26 +1,39 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
     kompose.cmd: kompose -f docker-compose.yml convert
     kompose.version: 1.16.0 (0c01309)
-  creationTimestamp: null
   labels:
     io.kompose.service: mongodb
   name: mongodb
   namespace: incap
 spec:
   replicas: 1
-  strategy: {}
+  selector:
+    matchLabels:
+      io.kompose.service: mongodb
+  strategy:
+    type: RollingUpdate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.service: mongodb
     spec:
       containers:
         - image: mongo
+          imagePullPolicy: IfNotPresent
           name: mongodb
+          livenessProbe:
+            tcpSocket:
+              port: 27017
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          readinessProbe:
+            tcpSocket:
+              port: 27017
+            initialDelaySeconds: 10
+            periodSeconds: 10
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
@@ -31,4 +44,3 @@ spec:
             - containerPort: 27017
           resources: {}
       restartPolicy: Always
-status: {}

--- a/deploy/mongodb-service.yaml
+++ b/deploy/mongodb-service.yaml
@@ -7,10 +7,12 @@ metadata:
   creationTimestamp: null
   labels:
     io.kompose.service: mongodb
+    name: mongodb
   name: mongodb
+  namespace: incap
 spec:
   ports:
-  - name: "27017"
+  - name: "mongodb"
     port: 27017
     targetPort: 27017
   selector:

--- a/deploy/mongodb-service.yaml
+++ b/deploy/mongodb-service.yaml
@@ -4,18 +4,16 @@ metadata:
   annotations:
     kompose.cmd: kompose -f docker-compose.yml convert
     kompose.version: 1.16.0 (0c01309)
-  creationTimestamp: null
   labels:
     io.kompose.service: mongodb
     name: mongodb
   name: mongodb
   namespace: incap
 spec:
+  type: ClusterIP
   ports:
   - name: "mongodb"
     port: 27017
     targetPort: 27017
   selector:
     io.kompose.service: mongodb
-status:
-  loadBalancer: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       CATEGORIES_API_URL: http://backend:4000/categories
       USERS_API_URL: http://backend:4000/users
       ARTICLES_API_URL: http://backend:4000/articles
+      COMMENTS_API_URL: http://backend:4000/comments
     depends_on:
       - backend
 

--- a/docs/backend-technical-details.md
+++ b/docs/backend-technical-details.md
@@ -4,48 +4,63 @@
 
 The backend is now part of an Nx monorepo. Build, test, and lint using Nx CLI:
 
-- Build: `npx nx build backend`
-- Test: `npx nx test backend`
-- Lint: `npx nx lint backend`
+- Build: `npx nx build backend` - Test: `npx nx test backend` - Lint: `npx nx
+  lint backend`
 
 See [docs/nx-monorepo-migration.md](docs/nx-monorepo-migration.md) for details.
 
 ## Overview
 
-The INCAP backend is a RESTful API server built with Express.js and TypeScript, providing complete CRUD operations for articles, categories, and users. It demonstrates a clean three-layer architecture with proper separation of concerns.
+The INCAP backend is a RESTful API server built with Express.js and TypeScript,
+providing complete CRUD operations for articles, categories, and users. It
+demonstrates a clean three-layer architecture with proper separation of
+concerns.
 
 ## Technology Stack
 
 ### Core Technologies
 
-- **Node.js**: 24.x - JavaScript runtime
-- **Express.js**: 5.2 - Web application framework
-- **TypeScript**: 5.9 - Type-safe language
-- **MongoDB**: Latest - NoSQL document database
-- **Mongoose**: 9.1 - ODM (Object Document Mapper)
+- **Node.js**: 24.x - JavaScript runtime - **Express.js**: 5.2 - Web application
+  framework - **TypeScript**: 5.9 - Type-safe language - **MongoDB**: Latest -
+  NoSQL document database - **Mongoose**: 9.1 - ODM (Object Document Mapper)
 
 ### Middleware & Utilities
+
 | Package | Version | Purpose |
-|---------|---------|---------|
+
+| --------- | --------- | --------- |
+
 | morgan | 1.10 | HTTP request logging |
+
 | cors | 2.8 | Cross-Origin Resource Sharing |
+
 | body-parser | 2.2 | Request body parsing |
+
 | express-async-handler | 1.2 | Async/await error handling |
 
 ### Development & Testing
+
 | Package | Version | Purpose |
-|---------|---------|---------|
+
+| --------- | --------- | --------- |
+
 | Vitest | 4.0 | Unit test runner |
+
 | Chai | 4.5 | Assertion library |
+
 | Sinon | 21.0 | Mocking & stubbing |
+
 | Supertest | 7.2 | HTTP assertion testing |
+
 | TypeScript | 5.9 | Type checking |
+
 | esbuild | 0.27 | Fast bundler |
+
 | ESLint | 9.39 | Code quality |
 
 ## Project Structure
 
-```
+```text
 backend/
 ├── src/
 │   ├── server.ts                  # Application bootstrap
@@ -116,7 +131,7 @@ Server.bootstrap();
 
 ### Startup Sequence
 
-```
+```text
 1. Import Express, MongoDB modules
 2. Create Server instance
    ├── Initialize Express app
@@ -142,17 +157,15 @@ private config() {
 
 **Middleware Order & Purpose**:
 
-1. **Security**: Disable X-Powered-By header
-2. **CORS**: Allow cross-origin requests
-3. **Body Parsing**: Parse JSON request bodies
-4. **Logging**: Log all HTTP requests
-5. **Routing**: Mount route handlers
+1. **Security**: Disable X-Powered-By header 2. **CORS**: Allow cross-origin
+   requests 3. **Body Parsing**: Parse JSON request bodies 4. **Logging**: Log
+   all HTTP requests 5. **Routing**: Mount route handlers
 
 ## Architecture Pattern: Three-Layer Model
 
 Each domain (Articles, Categories, Users) follows this pattern:
 
-```
+```text
 HTTP Request
     ↓
 ┌─────────────────────────────────────────┐
@@ -198,6 +211,7 @@ HTTP Request
 ### Routes Layer (article.routes.ts)
 
 **Defined Endpoints**:
+
 ```typescript
 router.get('/')                 // GET /articles?category=...
 router.get('/:id')              // GET /articles/:id
@@ -207,6 +221,7 @@ router.delete('/:id')           // DELETE /articles/:id
 ```
 
 **Example Route Handler**:
+
 ```typescript
 this.router.route('/').get(
     asyncHandler(async (_req, res) => {
@@ -221,10 +236,8 @@ this.router.route('/').get(
 
 **Responsibilities**:
 
-- Extract request parameters
-- Call service layer
-- Handle business logic coordination
-- Return data for response
+- Extract request parameters - Call service layer - Handle business logic
+  coordination - Return data for response
 
 ```typescript
 export class ArticleController {
@@ -262,21 +275,19 @@ export class ArticleController {
 
 **Responsibilities**:
 
-- Implement business rules
-- Data validation
-- Coordinate with models
-- Handle error cases
+- Implement business rules - Data validation - Coordinate with models - Handle
+  error cases
 
 **Typical Operations**:
 
-- `getAll(category?: string)` - Retrieve articles, optionally filtered
-- `getById(id: string)` - Find single article
-- `save(article: Article)` - Create or update
-- `delete(id: string)` - Remove article
+- `getAll(category?: string)` - Retrieve articles, optionally filtered -
+  `getById(id: string)` - Find single article - `save(article: Article)` -
+  Create or update - `delete(id: string)` - Remove article
 
 #### Model Layer (article.model.ts)
 
 **MongoDB Schema Definition**:
+
 ```typescript
 export interface Article extends Document<string> {
     title: string;
@@ -294,6 +305,7 @@ export const articleSchema = new Schema({
 ```
 
 **Mongoose Model Pattern**:
+
 ```typescript
 function getArticleModel(): Model<Article> {
     // Check if model exists
@@ -305,19 +317,20 @@ function getArticleModel(): Model<Article> {
 }
 
 // Factory function for instantiation
-const articleModelFactory = (...args) => 
+const articleModelFactory = (...args) =>
     new (getArticleModel())(...args);
 ```
 
 **Delegated Methods**:
+
 ```typescript
 const staticMethods = [
-    'find', 'findById', 'findOneAndDelete', 
-    'findOne', 'create', 'findByIdAndUpdate', 
+    'find', 'findById', 'findOneAndDelete',
+    'findOne', 'create', 'findByIdAndUpdate',
     'findOneAndUpdate', 'deleteOne'
 ];
 for (const name of staticMethods) {
-    articleModelFactory[name] = (...args) => 
+    articleModelFactory[name] = (...args) =>
         getArticleModel()[name](...args);
 }
 ```
@@ -327,6 +340,7 @@ for (const name of staticMethods) {
 ### Article Model
 
 **Schema**:
+
 ```typescript
 {
     title: String,
@@ -341,6 +355,7 @@ for (const name of staticMethods) {
 ### Category Model
 
 **Schema**:
+
 ```typescript
 {
     name: String,
@@ -353,6 +368,7 @@ for (const name of staticMethods) {
 ### User Model
 
 **Schema**:
+
 ```typescript
 {
     username: String,
@@ -371,12 +387,13 @@ for (const name of staticMethods) {
 ### MongoDB Connection
 
 **Configuration**:
+
 ```typescript
 private dbConnection() {
     const mongoDbUrl = process.env.MONGO_DB_URL || "localhost:27017";
     mongoose.connect(`mongodb://${mongoDbUrl}/incap`);
     mongoose.set('strictQuery', false);
-    
+
     const connection = mongoose.connection;
     connection.once("open", () => {
         console.log("MongoDB connection established!");
@@ -391,16 +408,20 @@ private dbConnection() {
 ### Collections
 
 | Collection | Purpose | Documents |
-|-----------|---------|-----------|
+
+| ----------- | --------- | ----------- |
+
 | articles | Store article content | Article documents |
+
 | categories | Store category taxonomy | Category documents |
+
 | users | Store user information | User documents |
 
 ## API Endpoints
 
 ### Articles API
 
-```
+```text
 GET    /articles
        - Query: ?category=categoryName
        - Returns: Article[]
@@ -422,7 +443,7 @@ DELETE /articles/:id
 
 ### Categories API
 
-```
+```text
 GET    /categories
        - Returns: Category[]
 
@@ -443,7 +464,7 @@ DELETE /categories/:id
 
 ### Users API
 
-```
+```text
 GET    /users
        - Returns: User[]
 
@@ -481,6 +502,7 @@ router.route('/').get(asyncHandler(async (req, res) => {
 ### HTTP Response Pattern
 
 **Success Response**:
+
 ```json
 {
     "title": "Article Title",
@@ -492,6 +514,7 @@ router.route('/').get(asyncHandler(async (req, res) => {
 ```
 
 **Error Response** (Express default):
+
 ```json
 {
     "status": 500,
@@ -504,6 +527,7 @@ router.route('/').get(asyncHandler(async (req, res) => {
 ### Test Framework: Vitest
 
 **Configuration**:
+
 ```typescript
 export default defineConfig({
   test: {
@@ -528,6 +552,7 @@ export default defineConfig({
 ### Test Patterns
 
 **Unit Test Example**:
+
 ```typescript
 describe('ArticleController', () => {
     let controller: ArticleController;
@@ -567,6 +592,7 @@ npm run coverage
 ### TypeScript Compilation
 
 **tsconfig.json**:
+
 ```json
 {
     "compilerOptions": {
@@ -582,24 +608,26 @@ npm run coverage
 ### Production Build
 
 **esbuild Configuration**:
+
 ```bash
 esbuild server.ts --outdir=dist --bundle --platform=node
 ```
 
 **Results**:
 
-- Single bundled file at `dist/server.js`
-- All dependencies included
-- Optimized for Node.js environment
+- Single bundled file at `dist/server.js` - All dependencies included -
+  Optimized for Node.js environment
 
 ### Running the Application
 
 **Development**:
+
 ```bash
 npm run test:watch
 ```
 
 **Production**:
+
 ```bash
 npm run build
 npm run start
@@ -610,34 +638,35 @@ npm run start
 ### Morgan HTTP Logger
 
 **Configuration**:
+
 ```typescript
 this.app.use(morgan('combined'));
 ```
 
 **Logs Format**:
-```
+
+```text
 127.0.0.1 - - [timestamp] "GET /articles HTTP/1.1" 200 1234
 ```
 
 **Information Captured**:
 
-- Remote IP address
-- Request timestamp
-- HTTP method and path
-- Status code
-- Response size
+- Remote IP address - Request timestamp - HTTP method and path - Status code -
+  Response size
 
 ## Security Considerations
 
 ### CORS Configuration
+
 ```typescript
 this.app.use(cors());
 ```
 
-- Allows requests from any origin
-- Configurable for production (should restrict domains)
+- Allows requests from any origin - Configurable for production (should restrict
+  domains)
 
 ### Headers
+
 ```typescript
 this.app.disable('x-powered-by');
 ```
@@ -646,9 +675,8 @@ this.app.disable('x-powered-by');
 
 ### Input Validation
 
-- Express.json() built-in body size limits
-- QueryString parsing by Express
-- Type-safe through TypeScript
+- Express.json() built-in body size limits - QueryString parsing by Express -
+  Type-safe through TypeScript
 
 ---
 

--- a/docs/cicd-and-analysis.md
+++ b/docs/cicd-and-analysis.md
@@ -2,21 +2,22 @@
 
 ## Overview
 
-This repository uses an Nx monorepo layout with separate frontend and backend applications under `apps/`. CI is split across GitHub Actions, CircleCI, and AppVeyor:
+This repository uses an Nx monorepo layout with separate frontend and backend
+applications under `apps/`. CI is split across GitHub Actions, CircleCI, and
+AppVeyor:
 
-- GitHub Actions runs rebuild jobs on Ubuntu for Node.js 20, 22, and 24.
-- GitHub Actions also builds Docker images and pushes them to Docker Hub on `master`.
-- CircleCI rebuilds frontend and backend, then uploads coverage to Coveralls and Codacy.
-- AppVeyor runs the Windows rebuild path, uploads test results and coverage, monitors dependencies with Snyk, and submits SonarCloud analysis.
+- GitHub Actions runs rebuild jobs on Ubuntu for Node.js 20, 22, and 24. -
+  GitHub Actions also builds Docker images and pushes them to Docker Hub on
+  `master`. - CircleCI rebuilds frontend and backend, then uploads coverage to
+  Coveralls and Codacy. - AppVeyor runs the Windows rebuild path, uploads test
+  results and coverage, monitors dependencies with Snyk, and submits SonarCloud
+  analysis.
 
 ## Repository Layout Used by CI
 
-- Frontend app: `apps/frontend`
-- Backend app: `apps/backend`
-- Nx workspace config: `nx.json`
-- Root package manifest: `package.json`
-- Windows rebuild scripts: `rebuild.cmd`, `rebuild.ps1`
-- POSIX rebuild script: `rebuild.sh`
+- Frontend app: `apps/frontend` - Backend app: `apps/backend` - Nx workspace
+  config: `nx.json` - Root package manifest: `package.json` - Windows rebuild
+  scripts: `rebuild.cmd`, `rebuild.ps1` - POSIX rebuild script: `rebuild.sh`
 
 ## Shared Rebuild Scripts
 
@@ -24,21 +25,27 @@ The rebuild scripts are the main entry points used by CI.
 
 ### `rebuild.cmd`
 
-`rebuild.cmd` installs dependencies with `npm ci --legacy-peer-deps` and then runs Nx targets for either `frontend`, `backend`, or both:
+`rebuild.cmd` installs dependencies with `npm ci --legacy-peer-deps` and then
+runs Nx targets for either `frontend`, `backend`, or both:
 
-- `npm run build:frontend` / `npm run build:backend`
-- `npm run test:frontend:coverage` / `npm run test:backend:coverage`
-- `npm run lint:frontend` / `npm run lint:backend`
+- `npm run build:frontend` / `npm run build:backend` - `npm run
+  test:frontend:coverage` / `npm run test:backend:coverage` - `npm run
+  lint:frontend` / `npm run lint:backend`
 
-When no argument is provided, it runs the full workspace build, coverage, and lint flow.
+When no argument is provided, it runs the full workspace build, coverage, and
+lint flow.
 
 ### `rebuild.ps1`
 
-`rebuild.ps1` starts two background jobs and runs `rebuild.cmd frontend` and `rebuild.cmd backend` in parallel. This script is useful on Windows, but the current AppVeyor pipeline invokes `rebuild.cmd` directly rather than `rebuild.ps1`.
+`rebuild.ps1` starts two background jobs and runs `rebuild.cmd frontend` and
+`rebuild.cmd backend` in parallel. This script is useful on Windows, but the
+current AppVeyor pipeline invokes `rebuild.cmd` directly rather than
+`rebuild.ps1`.
 
 ### `rebuild.sh`
 
-`rebuild.sh` mirrors the same Nx-based behavior for Linux runners and is used by GitHub Actions and CircleCI.
+`rebuild.sh` mirrors the same Nx-based behavior for Linux runners and is used by
+GitHub Actions and CircleCI.
 
 ## GitHub Actions
 
@@ -48,16 +55,15 @@ When no argument is provided, it runs the full workspace build, coverage, and li
 
 This workflow runs on:
 
-- `push` to `master`
-- `pull_request` targeting `master`
-- published releases
+- `push` to `master` - `pull_request` targeting `master` - published releases
 
 It defines two jobs:
 
-- `build-frontend`
-- `build-backend`
+- `build-frontend` - `build-backend`
 
-Each job runs on `ubuntu-latest` and tests a Node.js matrix of `20`, `22`, and `24`. The frontend job additionally installs Angular CLI before running `bash rebuild.sh frontend`.
+Each job runs on `ubuntu-latest` and tests a Node.js matrix of `20`, `22`, and
+`24`. The frontend job additionally installs Angular CLI before running `bash
+rebuild.sh frontend`.
 
 ### Docker Image Workflow
 
@@ -65,21 +71,19 @@ Each job runs on `ubuntu-latest` and tests a Node.js matrix of `20`, `22`, and `
 
 This workflow runs on:
 
-- `push` to `master`
-- `pull_request` targeting `master`
-- published releases
+- `push` to `master` - `pull_request` targeting `master` - published releases
 
 It builds Docker images from:
 
-- `apps/frontend/Dockerfile`
-- `apps/backend/Dockerfile`
+- `apps/frontend/Dockerfile` - `apps/backend/Dockerfile`
 
-Image push happens only when `github.ref == 'refs/heads/master'`. Pull requests and releases still build the images, but they do not push unless the workflow is running on the `master` branch.
+Image push happens only when `github.ref == 'refs/heads/master'`. Pull requests
+and releases still build the images, but they do not push unless the workflow is
+running on the `master` branch.
 
 Published image names:
 
-- `tuanicom/incap-frontend:latest`
-- `tuanicom/incap-backend:latest`
+- `tuanicom/incap-frontend:latest` - `tuanicom/incap-backend:latest`
 
 ## CircleCI
 
@@ -87,40 +91,40 @@ Published image names:
 
 CircleCI defines three jobs:
 
-- `build-frontend`
-- `build-backend`
-- `finalize`
+- `build-frontend` - `build-backend` - `finalize`
 
 ### Frontend job
 
-The frontend job uses `cimg/node:lts-browsers`, installs Chrome and Chromedriver, runs `bash rebuild.sh frontend`, then uploads coverage:
+The frontend job uses `cimg/node:lts-browsers`, installs Chrome and
+Chromedriver, runs `bash rebuild.sh frontend`, then uploads coverage:
 
-- Coveralls input: `apps/frontend/coverage/frontend/lcov.info`
-- Codacy input: `apps/frontend/coverage/frontend/lcov.info`
+- Coveralls input: `apps/frontend/coverage/frontend/lcov.info` - Codacy input:
+  `apps/frontend/coverage/frontend/lcov.info`
 
 Stored outputs:
 
-- test results from `apps/frontend/tests-results`
-- coverage artifacts from `apps/frontend/coverage`
+- test results from `apps/frontend/tests-results` - coverage artifacts from
+  `apps/frontend/coverage`
 
 ### Backend job
 
-The backend job uses `cimg/node:lts`, runs `bash rebuild.sh backend`, then uploads coverage:
+The backend job uses `cimg/node:lts`, runs `bash rebuild.sh backend`, then
+uploads coverage:
 
-- Coveralls input: `coverage/apps/backend/lcov.info`
-- Codacy input: `coverage/apps/backend/lcov.info`
+- Coveralls input: `coverage/apps/backend/lcov.info` - Codacy input:
+  `coverage/apps/backend/lcov.info`
 
 Stored outputs:
 
-- test results from `apps/backend/tests-results`
-- coverage artifacts from `coverage/apps/backend`
+- test results from `apps/backend/tests-results` - coverage artifacts from
+  `coverage/apps/backend`
 
 ### Finalize job
 
-The `finalize` job runs after both build jobs complete and finalizes parallel coverage reporting for:
+The `finalize` job runs after both build jobs complete and finalizes parallel
+coverage reporting for:
 
-- Coveralls
-- Codacy
+- Coveralls - Codacy
 
 ## AppVeyor
 
@@ -128,59 +132,45 @@ The `finalize` job runs after both build jobs complete and finalizes parallel co
 
 AppVeyor runs on `Visual Studio 2022` and currently:
 
-- installs Node.js `24.13.0`
-- installs `sonar-scanner`
-- installs `snyk`
-- installs `codecov-cli` with `pip`
-- runs `rebuild.cmd`
-- uploads JUnit XML test results from both apps
-- uploads coverage via `codecovcli`
-- runs `snyk monitor`
-- runs SonarCloud analysis with PR-aware arguments when applicable
+- installs Node.js `24.13.0` - installs `sonar-scanner` - installs `snyk` -
+  installs `codecov-cli` with `pip` - runs `rebuild.cmd` - uploads JUnit XML
+  test results from both apps - uploads coverage via `codecovcli` - runs `snyk
+  monitor` - runs SonarCloud analysis with PR-aware arguments when applicable
 
 Current cache entries:
 
-- `C:\Users\appveyor\AppData\Roaming\npm\node_modules`
-- `C:\Users\appveyor\AppData\Roaming\npm-cache`
-- `node_modules`
+- `C:\Users\appveyor\AppData\Roaming\npm\node_modules` -
+  `C:\Users\appveyor\AppData\Roaming\npm-cache` - `node_modules`
 
 Artifacts published by AppVeyor:
 
-- `apps/frontend/coverage`
-- `coverage/apps/backend`
-- `apps/frontend/eslint.json`
-- `apps/backend/eslint.json`
+- `apps/frontend/coverage` - `coverage/apps/backend` -
+  `apps/frontend/eslint.json` - `apps/backend/eslint.json`
 
 ## Nx Commands Used by CI
 
 These root scripts are defined in `package.json`:
 
-- `npm run build`
-- `npm run build:frontend`
-- `npm run build:backend`
-- `npm run test`
-- `npm run test:frontend`
-- `npm run test:backend`
-- `npm run test:coverage`
-- `npm run test:frontend:coverage`
-- `npm run test:backend:coverage`
-- `npm run lint`
-- `npm run lint:frontend`
-- `npm run lint:backend`
+- `npm run build` - `npm run build:frontend` - `npm run build:backend` - `npm
+  run test` - `npm run test:frontend` - `npm run test:backend` - `npm run
+  test:coverage` - `npm run test:frontend:coverage` - `npm run
+  test:backend:coverage` - `npm run lint` - `npm run lint:frontend` - `npm run
+  lint:backend`
 
 The workspace is currently on Nx `22.6.3`.
 
 ## Test and Coverage Outputs
 
-The repository currently uses different coverage output locations for the two apps:
+The repository currently uses different coverage output locations for the two
+apps:
 
-- Frontend LCOV: `apps/frontend/coverage/frontend/lcov.info`
-- Backend LCOV: `coverage/apps/backend/lcov.info`
+- Frontend LCOV: `apps/frontend/coverage/frontend/lcov.info` - Backend LCOV:
+  `coverage/apps/backend/lcov.info`
 
 JUnit test result locations used in CI:
 
-- `apps/frontend/tests-results/tests-results.xml`
-- `apps/backend/tests-results/tests-results.xml`
+- `apps/frontend/tests-results/tests-results.xml` -
+  `apps/backend/tests-results/tests-results.xml`
 
 ## SonarCloud
 
@@ -188,37 +178,34 @@ JUnit test result locations used in CI:
 
 SonarCloud is configured with:
 
-- organization: `tuanicom-github`
-- project key: `tuanicom_incap`
-- sources: `apps/frontend/src/app,apps/backend/src`
-- tests: `apps/frontend/src/app,apps/backend/src`
-- LCOV paths:
-  - `apps/frontend/coverage/frontend/lcov.info`
-  - `coverage/apps/backend/lcov.info`
-- ESLint reports:
-  - `apps/frontend/eslint.json`
-  - `apps/backend/eslint.json`
+- organization: `tuanicom-github` - project key: `tuanicom_incap` - sources:
+  `apps/frontend/src/app,apps/backend/src` - tests:
+  `apps/frontend/src/app,apps/backend/src` - LCOV paths: -
+  `apps/frontend/coverage/frontend/lcov.info` -
+  `coverage/apps/backend/lcov.info` - ESLint reports: -
+  `apps/frontend/eslint.json` - `apps/backend/eslint.json`
 
-AppVeyor passes either PR analysis arguments or branch analysis arguments before calling `sonar-scanner`.
+AppVeyor passes either PR analysis arguments or branch analysis arguments before
+calling `sonar-scanner`.
 
 ## Security Scanning
 
 Snyk is currently integrated through AppVeyor, which runs:
 
-- `snyk auth %snyk_token%`
-- `snyk monitor --non-interactive --fail-fast`
+- `snyk auth %snyk_token%` - `snyk monitor --non-interactive --fail-fast`
 
-The repository also includes `snyk` and `@snyk/protect` as dependencies, but there are no root `package.json` scripts dedicated to Snyk at the moment.
+The repository also includes `snyk` and `@snyk/protect` as dependencies, but
+there are no root `package.json` scripts dedicated to Snyk at the moment.
 
 ## Branch and Trigger Notes
 
-The active CI workflows shown in this repository are branch-based on `master`, not `main`.
+The active CI workflows shown in this repository are branch-based on `master`,
+not `main`.
 
 That applies to:
 
-- `.github/workflows/rebuild.yml`
-- `.github/workflows/docker-image.yml`
-- README badges that reference `master`
+- `.github/workflows/rebuild.yml` - `.github/workflows/docker-image.yml` -
+  README badges that reference `master`
 
 ## Local CI Simulation
 
@@ -249,5 +236,4 @@ On Windows:
 
 ## Related Files
 
-- [Deployment Guide](./deployment.md)
-- [README](../README.md)
+- [Deployment Guide](./deployment.md) - [README](../README.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,14 +4,13 @@
 
 This repository ships deployment assets for three main scenarios:
 
-- local runtime wiring with `docker-compose.yml`
-- local image build or image pull flows with `docker-compose-build.yml` and `docker-compose-image.yml`
-- Kubernetes manifests under `deploy/`
+- local runtime wiring with `docker-compose.yml` - local image build or image
+  pull flows with `docker-compose-build.yml` and `docker-compose-image.yml` -
+  Kubernetes manifests under `deploy/`
 
 The frontend and backend Dockerfiles live in the Nx monorepo under:
 
-- `apps/frontend/Dockerfile`
-- `apps/backend/Dockerfile`
+- `apps/frontend/Dockerfile` - `apps/backend/Dockerfile`
 
 ## Docker Images
 
@@ -23,24 +22,22 @@ The frontend image is built from the monorepo root context.
 
 Build stage:
 
-- base image: `node:22-alpine`
-- copies `package*.json`, `nx.json`, `tsconfig.base.json`, and `apps/frontend`
-- installs dependencies with `npm ci --legacy-peer-deps`
-- runs `npm run build:frontend`
+- base image: `node:22-alpine` - copies `package*.json`, `nx.json`,
+  `tsconfig.base.json`, and `apps/frontend` - installs dependencies with `npm ci
+  --legacy-peer-deps` - runs `npm run build:frontend`
 
 Runtime stage:
 
-- base image: `nginx:1.29.4-alpine3.23-slim`
-- serves files from `dist/apps/frontend/browser/`
-- exposes port `8080`
-- injects runtime API endpoints into nginx config via `envsubst`
+- base image: `nginx:1.29.4-alpine3.23-slim` - serves files from
+  `dist/apps/frontend/browser/` - exposes port `8080` - injects runtime API
+  endpoints into nginx config via `envsubst`
 
 Default runtime environment variables:
 
-- `CATEGORIES_API_URL=http://incap-backend:4000/categories`
-- `USERS_API_URL=http://incap-backend:4000/users`
-- `ARTICLES_API_URL=http://incap-backend:4000/articles`
-- `COMMENTS_API_URL=http://incap-backend:4000/comments`
+- `CATEGORIES_API_URL=http://incap-backend:4000/categories` -
+  `USERS_API_URL=http://incap-backend:4000/users` -
+  `ARTICLES_API_URL=http://incap-backend:4000/articles` -
+  `COMMENTS_API_URL=http://incap-backend:4000/comments`
 
 Published image tag:
 
@@ -54,22 +51,18 @@ The backend image is also built from the monorepo root context.
 
 Build stage:
 
-- base image: `node:22-alpine`
-- copies `package*.json` and `apps/backend`
-- installs dependencies with `npm ci --legacy-peer-deps`
-- runs `npm --prefix apps/backend run build`
+- base image: `node:22-alpine` - copies `package*.json` and `apps/backend` -
+  installs dependencies with `npm ci --legacy-peer-deps` - runs `npm --prefix
+  apps/backend run build`
 
 Runtime stage:
 
-- base image: `node:22-alpine`
-- copies `apps/backend/dist/server.js` into the runtime image
-- creates and uses a non-root user
-- exposes port `4000`
+- base image: `node:22-alpine` - copies `apps/backend/dist/server.js` into the
+  runtime image - creates and uses a non-root user - exposes port `4000`
 
 Default runtime environment variables:
 
-- `NODE_ENV=production`
-- `MONGO_DB_URL=localhost:27017`
+- `NODE_ENV=production` - `MONGO_DB_URL=localhost:27017`
 
 Published image tag:
 
@@ -79,34 +72,33 @@ Published image tag:
 
 ### `docker-compose.yml`
 
-This file documents runtime relationships between the three services and is the simplest local orchestration entry point.
+This file documents runtime relationships between the three services and is the
+simplest local orchestration entry point.
 
 Defined services:
 
-- `frontend`
-- `backend`
-- `mongodb`
+- `frontend` - `backend` - `mongodb`
 
 Current configuration in the file:
 
-- frontend publishes `8080:8080`
-- frontend uses:
-  - `CATEGORIES_API_URL=http://backend:4000/categories`
-  - `USERS_API_URL=http://backend:4000/users`
-  - `ARTICLES_API_URL=http://backend:4000/articles`
-  - `COMMENTS_API_URL=http://backend:4000/comments`
-- backend uses `MONGO_DB_URL=mongodb:27017`
-- mongodb uses the official `mongo` image
+- frontend publishes `8080:8080` - frontend uses: -
+  `CATEGORIES_API_URL=http://backend:4000/categories` -
+  `USERS_API_URL=http://backend:4000/users` -
+  `ARTICLES_API_URL=http://backend:4000/articles` -
+  `COMMENTS_API_URL=http://backend:4000/comments` - backend uses
+  `MONGO_DB_URL=mongodb:27017` - mongodb uses the official `mongo` image
 
-Important limitation: this file does not currently declare `build`, `image`, backend port publishing, MongoDB port publishing, or a persistent volume. It is useful as a lightweight wiring reference, but it is not a fully self-contained production compose stack.
+Important limitation: this file does not currently declare `build`, `image`,
+backend port publishing, MongoDB port publishing, or a persistent volume. It is
+useful as a lightweight wiring reference, but it is not a fully self-contained
+production compose stack.
 
 ### `docker-compose-build.yml`
 
 This file builds local images from source:
 
-- frontend build context: `apps/frontend`
-- backend build context: `apps/backend`
-- mongodb image: `mongo`
+- frontend build context: `apps/frontend` - backend build context:
+  `apps/backend` - mongodb image: `mongo`
 
 Use it when you want Docker to build the application images locally.
 
@@ -114,19 +106,20 @@ Use it when you want Docker to build the application images locally.
 
 This file pulls prebuilt images instead of building them:
 
-- `tuanicom/incap-frontend`
-- `tuanicom/incap-backend`
+- `tuanicom/incap-frontend` - `tuanicom/incap-backend`
 
 Both services use `pull_policy: always`.
 
 ### `deploy/docker-compose.yml`
 
-This file is a separate deployment-oriented compose reference under `deploy/`. It uses service names `incap-frontend` and `incap-backend`, publishes both application ports, and configures the frontend with four runtime API endpoints:
+This file is a separate deployment-oriented compose reference under `deploy/`.
+It uses service names `incap-frontend` and `incap-backend`, publishes both
+application ports, and configures the frontend with four runtime API endpoints:
 
-- `CATEGORIES_API_URL=http://incap-backend:4000/categories`
-- `USERS_API_URL=http://incap-backend:4000/users`
-- `ARTICLES_API_URL=http://incap-backend:4000/articles`
-- `COMMENTS_API_URL=http://incap-backend:4000/comments`
+- `CATEGORIES_API_URL=http://incap-backend:4000/categories` -
+  `USERS_API_URL=http://incap-backend:4000/users` -
+  `ARTICLES_API_URL=http://incap-backend:4000/articles` -
+  `COMMENTS_API_URL=http://incap-backend:4000/comments`
 
 ## Running with Docker
 
@@ -148,14 +141,13 @@ docker-compose -f docker-compose-image.yml up -d
 
 Kubernetes assets are stored in `deploy/`:
 
-- `deploy/backend-deployment.yaml`
-- `deploy/backend-service.yaml`
-- `deploy/frontend-deployment.yaml`
-- `deploy/frontend-service.yaml`
-- `deploy/mongodb-deployment.yaml`
-- `deploy/mongodb-service.yaml`
+- `deploy/backend-deployment.yaml` - `deploy/backend-service.yaml` -
+  `deploy/frontend-deployment.yaml` - `deploy/frontend-service.yaml` -
+  `deploy/mongodb-deployment.yaml` - `deploy/mongodb-service.yaml`
 
-These files appear to be Kompose-generated manifests derived from an older compose definition and should be treated as baseline manifests rather than polished production Kubernetes resources.
+These files appear to be Kompose-generated manifests derived from an older
+compose definition and should be treated as baseline manifests rather than
+polished production Kubernetes resources.
 
 ### Backend Deployment
 
@@ -163,12 +155,11 @@ These files appear to be Kompose-generated manifests derived from an older compo
 
 Current characteristics:
 
-- `apiVersion: apps/v1`
-- image: `tuanicom/incap-backend`
-- env: `MONGO_DB_URL=mongodb:27017`
-- container port: `4000`
-- readiness and liveness probes use a TCP socket on port `4000`
-- security context sets `allowPrivilegeEscalation: false`, `runAsNonRoot: true`, and drops all capabilities
+- `apiVersion: apps/v1` - image: `tuanicom/incap-backend` - env:
+  `MONGO_DB_URL=mongodb:27017` - container port: `4000` - readiness and liveness
+  probes use a TCP socket on port `4000` - security context sets
+  `allowPrivilegeEscalation: false`, `runAsNonRoot: true`, and drops all
+  capabilities
 
 ### Backend Service
 
@@ -176,9 +167,7 @@ Current characteristics:
 
 Current characteristics:
 
-- service type: `ClusterIP`
-- service port: `4000`
-- target port: `4000`
+- service type: `ClusterIP` - service port: `4000` - target port: `4000`
 
 ### Frontend Deployment
 
@@ -186,15 +175,12 @@ Current characteristics:
 
 Current characteristics:
 
-- `apiVersion: apps/v1`
-- image: `tuanicom/incap-frontend`
-- env:
-  - `CATEGORIES_API_URL=http://incap-backend:4000/categories`
-  - `USERS_API_URL=http://incap-backend:4000/users`
-  - `ARTICLES_API_URL=http://incap-backend:4000/articles`
-  - `COMMENTS_API_URL=http://incap-backend:4000/comments`
-- container port: `8080`
-- readiness and liveness probes use `GET /` on port `8080`
+- `apiVersion: apps/v1` - image: `tuanicom/incap-frontend` - env: -
+  `CATEGORIES_API_URL=http://incap-backend:4000/categories` -
+  `USERS_API_URL=http://incap-backend:4000/users` -
+  `ARTICLES_API_URL=http://incap-backend:4000/articles` -
+  `COMMENTS_API_URL=http://incap-backend:4000/comments` - container port: `8080`
+  - readiness and liveness probes use `GET /` on port `8080`
 
 ### Frontend Service
 
@@ -202,25 +188,20 @@ Current characteristics:
 
 Current characteristics:
 
-- service type: `LoadBalancer`
-- service port: `80`
-- target port: `8080`
+- service type: `LoadBalancer` - service port: `80` - target port: `8080`
 
 ### MongoDB
 
 **Files**:
 
-- `deploy/mongodb-deployment.yaml`
-- `deploy/mongodb-service.yaml`
+- `deploy/mongodb-deployment.yaml` - `deploy/mongodb-service.yaml`
 
 Current characteristics:
 
-- image: `mongo`
-- deployment uses `apiVersion: apps/v1`
-- service type: `ClusterIP`
-- service port: `27017`
-- readiness and liveness probes use a TCP socket on port `27017`
-- no persistent volume claim is defined in the repository
+- image: `mongo` - deployment uses `apiVersion: apps/v1` - service type:
+  `ClusterIP` - service port: `27017` - readiness and liveness probes use a TCP
+  socket on port `27017` - no persistent volume claim is defined in the
+  repository
 
 ## Applying the Kubernetes Manifests
 
@@ -240,17 +221,17 @@ kubectl apply -f deploy/frontend-deployment.yaml -n incap
 
 The frontend runtime can be configured with:
 
-- `CATEGORIES_API_URL`
-- `USERS_API_URL`
-- `ARTICLES_API_URL`
-- `COMMENTS_API_URL`
+- `CATEGORIES_API_URL` - `USERS_API_URL` - `ARTICLES_API_URL` -
+  `COMMENTS_API_URL`
 
-Those variables are consumed by `apps/frontend/nginx.conf` and substituted at container startup by the frontend Docker image.
+Those variables are consumed by `apps/frontend/nginx.conf` and substituted at
+container startup by the frontend Docker image.
 
-The application code also still contains `assets/settings.json` support, so there are effectively two configuration mechanisms in the repository today:
+The application code also still contains `assets/settings.json` support, so
+there are effectively two configuration mechanisms in the repository today:
 
-- static/runtime file-based app settings inside the frontend app
-- nginx proxy endpoint injection through container environment variables
+- static/runtime file-based app settings inside the frontend app - nginx proxy
+  endpoint injection through container environment variables
 
 ### Backend
 
@@ -264,13 +245,17 @@ The default value in the server code and Dockerfile is `localhost:27017`.
 
 These are important operational caveats in the repository as it exists today:
 
-- The root `docker-compose.yml` is incomplete for a full fresh deployment because it does not specify image builds or published backend and MongoDB ports.
-- The root compose file also does not define a named volume for MongoDB persistence.
-- The backend and MongoDB services are cluster-internal `ClusterIP` services, while the frontend remains a `LoadBalancer`; there is still no ingress layer or host/path-based routing configuration in the repository.
-- The frontend runtime now depends on four per-endpoint API URL variables, so any additional compose or Kubernetes overlays need to define all four consistently.
-- No persistent storage manifest for MongoDB is present under `deploy/`.
+- The root `docker-compose.yml` is incomplete for a full fresh deployment
+  because it does not specify image builds or published backend and MongoDB
+  ports. - The root compose file also does not define a named volume for MongoDB
+  persistence. - The backend and MongoDB services are cluster-internal
+  `ClusterIP` services, while the frontend remains a `LoadBalancer`; there is
+  still no ingress layer or host/path-based routing configuration in the
+  repository. - The frontend runtime now depends on four per-endpoint API URL
+  variables, so any additional compose or Kubernetes overlays need to define all
+  four consistently. - No persistent storage manifest for MongoDB is present
+  under `deploy/`.
 
 ## Related Files
 
-- [CI/CD and Code Analysis](./cicd-and-analysis.md)
-- [README](../README.md)
+- [CI/CD and Code Analysis](./cicd-and-analysis.md) - [README](../README.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -163,10 +163,11 @@ These files appear to be Kompose-generated manifests derived from an older compo
 
 Current characteristics:
 
-- `apiVersion: extensions/v1beta1`
+- `apiVersion: apps/v1`
 - image: `tuanicom/incap-backend`
 - env: `MONGO_DB_URL=mongodb:27017`
 - container port: `4000`
+- readiness and liveness probes use a TCP socket on port `4000`
 - security context sets `allowPrivilegeEscalation: false`, `runAsNonRoot: true`, and drops all capabilities
 
 ### Backend Service
@@ -175,10 +176,9 @@ Current characteristics:
 
 Current characteristics:
 
-- service type: `NodePort`
+- service type: `ClusterIP`
 - service port: `4000`
 - target port: `4000`
-- node port: `30400`
 
 ### Frontend Deployment
 
@@ -186,7 +186,7 @@ Current characteristics:
 
 Current characteristics:
 
-- `apiVersion: extensions/v1beta1`
+- `apiVersion: apps/v1`
 - image: `tuanicom/incap-frontend`
 - env:
   - `CATEGORIES_API_URL=http://incap-backend:4000/categories`
@@ -194,6 +194,7 @@ Current characteristics:
   - `ARTICLES_API_URL=http://incap-backend:4000/articles`
   - `COMMENTS_API_URL=http://incap-backend:4000/comments`
 - container port: `8080`
+- readiness and liveness probes use `GET /` on port `8080`
 
 ### Frontend Service
 
@@ -215,7 +216,10 @@ Current characteristics:
 Current characteristics:
 
 - image: `mongo`
+- deployment uses `apiVersion: apps/v1`
+- service type: `ClusterIP`
 - service port: `27017`
+- readiness and liveness probes use a TCP socket on port `27017`
 - no persistent volume claim is defined in the repository
 
 ## Applying the Kubernetes Manifests
@@ -262,10 +266,8 @@ These are important operational caveats in the repository as it exists today:
 
 - The root `docker-compose.yml` is incomplete for a full fresh deployment because it does not specify image builds or published backend and MongoDB ports.
 - The root compose file also does not define a named volume for MongoDB persistence.
-- The Kubernetes deployments still use deprecated `extensions/v1beta1` API versions.
-- The Kubernetes services are `LoadBalancer` and still lack an ingress layer or cluster-internal/frontend-specific routing strategy beyond the service exposure.
+- The backend and MongoDB services are cluster-internal `ClusterIP` services, while the frontend remains a `LoadBalancer`; there is still no ingress layer or host/path-based routing configuration in the repository.
 - The frontend runtime now depends on four per-endpoint API URL variables, so any additional compose or Kubernetes overlays need to define all four consistently.
-- No health probes are defined in the Kubernetes manifests.
 - No persistent storage manifest for MongoDB is present under `deploy/`.
 
 ## Related Files

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -37,9 +37,10 @@ Runtime stage:
 
 Default runtime environment variables:
 
-- `CATEGORIES_API_URL=http://localhost/api/categories`
-- `USERS_API_URL=http://localhost/api/users`
-- `ARTICLES_API_URL=http://localhost/api/articles`
+- `CATEGORIES_API_URL=http://incap-backend:4000/categories`
+- `USERS_API_URL=http://incap-backend:4000/users`
+- `ARTICLES_API_URL=http://incap-backend:4000/articles`
+- `COMMENTS_API_URL=http://incap-backend:4000/comments`
 
 Published image tag:
 
@@ -93,6 +94,7 @@ Current configuration in the file:
   - `CATEGORIES_API_URL=http://backend:4000/categories`
   - `USERS_API_URL=http://backend:4000/users`
   - `ARTICLES_API_URL=http://backend:4000/articles`
+  - `COMMENTS_API_URL=http://backend:4000/comments`
 - backend uses `MONGO_DB_URL=mongodb:27017`
 - mongodb uses the official `mongo` image
 
@@ -119,9 +121,12 @@ Both services use `pull_policy: always`.
 
 ### `deploy/docker-compose.yml`
 
-This file is a separate deployment-oriented compose reference under `deploy/`. It uses service names `incap-frontend` and `incap-backend`, publishes both application ports, and points the frontend category API to `http://localhost:4000/categories`.
+This file is a separate deployment-oriented compose reference under `deploy/`. It uses service names `incap-frontend` and `incap-backend`, publishes both application ports, and configures the frontend with four runtime API endpoints:
 
-Unlike the root `docker-compose.yml`, it does not define all three frontend API environment variables.
+- `CATEGORIES_API_URL=http://incap-backend:4000/categories`
+- `USERS_API_URL=http://incap-backend:4000/users`
+- `ARTICLES_API_URL=http://incap-backend:4000/articles`
+- `COMMENTS_API_URL=http://incap-backend:4000/comments`
 
 ## Running with Docker
 
@@ -183,10 +188,12 @@ Current characteristics:
 
 - `apiVersion: extensions/v1beta1`
 - image: `tuanicom/incap-frontend`
-- only one env variable is present: `CATEGORIES_API_URL=http://localhost:4000`
+- env:
+  - `CATEGORIES_API_URL=http://incap-backend:4000/categories`
+  - `USERS_API_URL=http://incap-backend:4000/users`
+  - `ARTICLES_API_URL=http://incap-backend:4000/articles`
+  - `COMMENTS_API_URL=http://incap-backend:4000/comments`
 - container port: `8080`
-
-Note that this does not mirror the frontend Dockerfile defaults, which define three API URL variables.
 
 ### Frontend Service
 
@@ -194,10 +201,9 @@ Note that this does not mirror the frontend Dockerfile defaults, which define th
 
 Current characteristics:
 
-- service type: `NodePort`
-- service port: `8080`
+- service type: `LoadBalancer`
+- service port: `80`
 - target port: `8080`
-- node port: `30080`
 
 ### MongoDB
 
@@ -233,6 +239,7 @@ The frontend runtime can be configured with:
 - `CATEGORIES_API_URL`
 - `USERS_API_URL`
 - `ARTICLES_API_URL`
+- `COMMENTS_API_URL`
 
 Those variables are consumed by `apps/frontend/nginx.conf` and substituted at container startup by the frontend Docker image.
 
@@ -256,8 +263,8 @@ These are important operational caveats in the repository as it exists today:
 - The root `docker-compose.yml` is incomplete for a full fresh deployment because it does not specify image builds or published backend and MongoDB ports.
 - The root compose file also does not define a named volume for MongoDB persistence.
 - The Kubernetes deployments still use deprecated `extensions/v1beta1` API versions.
-- The Kubernetes services are `NodePort`, not `ClusterIP` or `LoadBalancer`.
-- The frontend Kubernetes deployment sets only `CATEGORIES_API_URL`, while the frontend Docker image expects three API URL variables.
+- The Kubernetes services are `LoadBalancer` and still lack an ingress layer or cluster-internal/frontend-specific routing strategy beyond the service exposure.
+- The frontend runtime now depends on four per-endpoint API URL variables, so any additional compose or Kubernetes overlays need to define all four consistently.
 - No health probes are defined in the Kubernetes manifests.
 - No persistent storage manifest for MongoDB is present under `deploy/`.
 

--- a/docs/frontend-technical-details.md
+++ b/docs/frontend-technical-details.md
@@ -4,37 +4,36 @@
 
 The frontend is now part of an Nx monorepo. Build, test, and lint using Nx CLI:
 
-- Build: `npx nx build frontend`
-- Test: `npx nx test frontend`
-- Lint: `npx nx lint frontend`
+- Build: `npx nx build frontend` - Test: `npx nx test frontend` - Lint: `npx nx
+  lint frontend`
 
 See [docs/nx-monorepo-migration.md](docs/nx-monorepo-migration.md) for details.
 
 ## Overview
 
-The INCAP frontend is an Angular 21 Single Page Application (SPA) built with TypeScript, featuring a responsive Bootstrap 5 UI and modern Component-driven architecture.
+The INCAP frontend is an Angular 21 Single Page Application (SPA) built with
+TypeScript, featuring a responsive Bootstrap 5 UI and modern Component-driven
+architecture.
 
 ## Technology Stack
 
 ### Core Technologies
 
-- **Angular**: 21.1 - Modern framework for building SPAs
-- **TypeScript**: 5.9 - Type-safe language
-- **Bootstrap**: 5.3 - Responsive CSS framework
-- **ng-bootstrap**: 20.0 - Native Bootstrap components for Angular
-- **Font Awesome**: 7.1 - Comprehensive icon library
-- **RxJS**: 7.8 - Reactive programming with Observables
-- **SCSS**: Sass for stylesheets
+- **Angular**: 21.1 - Modern framework for building SPAs - **TypeScript**: 5.9 -
+  Type-safe language - **Bootstrap**: 5.3 - Responsive CSS framework -
+  **ng-bootstrap**: 20.0 - Native Bootstrap components for Angular - **Font
+  Awesome**: 7.1 - Comprehensive icon library - **RxJS**: 7.8 - Reactive
+  programming with Observables - **SCSS**: Sass for stylesheets
 
 ### Build & Development
 
-- **Angular CLI**: 21.1 - Build tooling and development server
-- **Vitest**: 4.0 - Fast unit test runner
-- **TypeScript Compiler**: 5.9 - Type checking and compilation
+- **Angular CLI**: 21.1 - Build tooling and development server - **Vitest**: 4.0
+  - Fast unit test runner - **TypeScript Compiler**: 5.9 - Type checking and
+  compilation
 
 ## Project Structure
 
-```
+```text
 frontend/
 ├── src/
 │   ├── index.html                 # Entry HTML file
@@ -95,6 +94,7 @@ AppModule
 ```
 
 **Configuration:**
+
 ```typescript
 @NgModule({
   declarations: [],
@@ -126,22 +126,20 @@ const routes: Routes = [
 
 **Routing Features:**
 
-- Lazy-loading for feature modules (reduce initial bundle size)
-- Component-based routing
-- Standalone components support
-- Future redirect capability for 404 handling
+- Lazy-loading for feature modules (reduce initial bundle size) -
+  Component-based routing - Standalone components support - Future redirect
+  capability for 404 handling
 
 ## Key Components
 
 ### App Component
+
 **Purpose**: Root application component
 
 **Responsibilities**:
 
-- Application shell
-- Global navigation
-- Layout structure
-- Component composition
+- Application shell - Global navigation - Layout structure - Component
+  composition
 
 ### App Settings Service
 
@@ -168,13 +166,14 @@ export class AppSettingsService {
 export class AppSettingsHttpService {
   public initializeApp(): void {
     this.http.get('assets/settings.json')
-      .subscribe((res: AppSettings) => 
+      .subscribe((res: AppSettings) =>
         this.appSettingsService.settings = res);
   }
 }
 ```
 
 **Configuration File** (`assets/settings.json`):
+
 ```json
 {
   "categoriesApiUrl": "http://backend:4000/categories",
@@ -184,8 +183,11 @@ export class AppSettingsHttpService {
 ```
 
 **Initialization Strategy**:
+
 ```typescript
-export function app_Init(appSettingsHttpService: AppSettingsHttpService): () => void {
+export function app_Init(
+  appSettingsHttpService: AppSettingsHttpService
+): () => void {
   return () => appSettingsHttpService.initializeApp();
 }
 
@@ -197,26 +199,25 @@ provideAppInitializer(() => {
 ```
 
 ### Admin Module
+
 **Purpose**: Content management interface (lazy-loaded)
 
 **Features**:
 
-- Article management
-- Category management
-- User management
+- Article management - Category management - User management
 
 ### Articles Module
+
 **Purpose**: Article browsing and display (lazy-loaded)
 
 **Features**:
 
-- Article list display
-- Category filtering
-- Article detail view
+- Article list display - Category filtering - Article detail view
 
 ## Styling Strategy
 
 ### Bootstrap 5 Integration
+
 ```typescript
 // In app.module.ts
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
@@ -230,16 +231,16 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 ```
 
 ### Global Styles
+
 **File**: `styles.scss`
 
 **Includes**:
 
-- Bootstrap CSS customization
-- Global theme variables
-- Application-wide styling
-- Font definitions
+- Bootstrap CSS customization - Global theme variables - Application-wide
+  styling - Font definitions
 
 ### Component Styles
+
 ```typescript
 @Component({
   selector: 'app-example',
@@ -253,6 +254,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 ### HttpClient Integration
 
 **Configuration** in app.module.ts:
+
 ```typescript
 providers: [
   provideHttpClient(withInterceptorsFromDi())
@@ -260,6 +262,7 @@ providers: [
 ```
 
 **Usage Pattern**:
+
 ```typescript
 constructor(private http: HttpClient) {}
 
@@ -273,17 +276,18 @@ this.http.post<Article>(this.settings.articlesApiUrl, newArticle)
 ```
 
 ### API URLs
+
 Dynamically configured from `settings.json`:
 
-- Articles API: `${articlesApiUrl}`
-- Categories API: `${categoriesApiUrl}`
-- Users API: `${usersApiUrl}`
+- Articles API: `${articlesApiUrl}` - Categories API: `${categoriesApiUrl}` -
+  Users API: `${usersApiUrl}`
 
 ## Testing Strategy
 
 ### Test Framework: Vitest
 
 **Configuration** (vitest.config.ts):
+
 ```typescript
 {
   environment: 'jsdom',
@@ -301,15 +305,16 @@ Dynamically configured from `settings.json`:
 ### Test Patterns
 
 **Component Testing**:
+
 ```typescript
 describe('ArticlesComponent', () => {
   it('should fetch articles on init', () => {
     // Arrange
     const mockArticles = [...];
-    
+
     // Act
     component.ngOnInit();
-    
+
     // Assert
     expect(component.articles).toEqual(mockArticles);
   });
@@ -317,6 +322,7 @@ describe('ArticlesComponent', () => {
 ```
 
 ### Running Tests
+
 ```bash
 # Unit tests
 npm run test:unit
@@ -331,30 +337,26 @@ npm run coverage
 ## Build Process
 
 ### Development Build
+
 ```bash
 npm start
 ```
 
-- Starts ng serve on port 8080
-- Features:
-  - Hot module reloading
-  - Source maps
-  - Full TypeScript compilation
-  - Proxy to backend (via `proxy.conf.json`)
+- Starts ng serve on port 8080 - Features: - Hot module reloading - Source maps
+  - Full TypeScript compilation - Proxy to backend (via `proxy.conf.json`)
 
 ### Production Build
+
 ```bash
 npm run build
 ```
 
-- Generates optimized bundle in `dist/`
-- Features:
-  - TreeShaking for dead code elimination
-  - Minification and compression
-  - AOT compilation
-  - Small bundle size
+- Generates optimized bundle in `dist/` - Features: - TreeShaking for dead code
+  elimination - Minification and compression - AOT compilation - Small bundle
+  size
 
 ### Proxy Configuration (proxy.conf.json)
+
 ```json
 {
   "/categories": {
@@ -378,17 +380,13 @@ npm run build
 
 **Dockerfile**:
 
-- Multi-stage build (angular build → nginx serve)
-- Builds production artifacts
-- Serves via nginx
-- Exposes port 8080
+- Multi-stage build (angular build → nginx serve) - Builds production artifacts
+  - Serves via nginx - Exposes port 8080
 
 **nginx Configuration** (nginx.conf):
 
-- Serves static files
-- Redirects SPA routes to index.html
-- Configures caching policies
-- Sets security headers
+- Serves static files - Redirects SPA routes to index.html - Configures caching
+  policies - Sets security headers
 
 ## Code Quality
 
@@ -396,20 +394,18 @@ npm run build
 
 **Features**:
 
-- TypeScript-specific rules
-- Angular best practices
-- Import organization
-- JSDoc enforcement
+- TypeScript-specific rules - Angular best practices - Import organization -
+  JSDoc enforcement
 
 ### Coverage Goals
 
-- Aim for high code coverage
-- Vitest provides incremental coverage reports
-- Integration with CI/CD pipeline
+- Aim for high code coverage - Vitest provides incremental coverage reports -
+  Integration with CI/CD pipeline
 
 ## Development Best Practices
 
 ### Standalone Components
+
 ```typescript
 @Component({
   selector: 'app-feature',
@@ -419,20 +415,23 @@ npm run build
 ```
 
 ### Lazy-Loading
+
 ```typescript
-{ 
-  path: 'admin', 
+{
+  path: 'admin',
   loadChildren: () => import('./admin/admin.module')
-    .then(m => m.AdminModule) 
+    .then(m => m.AdminModule)
 }
 ```
 
 ### Dependency Injection
+
 ```typescript
 constructor(private http: HttpClient) {}
 ```
 
 ### Reactive Programming
+
 ```typescript
 articles$ = this.articles.asObservable();
 
@@ -450,27 +449,22 @@ ngOnInit() {
 
 ### Development Environment (`environment.ts`)
 
-- API server: `http://localhost:4000`
-- Development mode: True
-- Remote service URLs configurable
+- API server: `http://localhost:4000` - Development mode: True - Remote service
+  URLs configurable
 
 ### Production Environment (`environment.prod.ts`)
 
-- API server: Production URL
-- Development mode: False
-- Optimizations enabled
+- API server: Production URL - Development mode: False - Optimizations enabled
 
 ## Angular Version Features
 
 ### Angular 21 Capabilities Used
 
-- Standalone components
-- Standalone API for modules
-- Improved change detection
-- Enhanced dependency injection
-- Typed reactive forms (planned)
-- Signal-based reactivity compatibility
+- Standalone components - Standalone API for modules - Improved change detection
+  - Enhanced dependency injection - Typed reactive forms (planned) -
+  Signal-based reactivity compatibility
 
 ---
 
-For API implementation details, see [Backend Technical Details](./backend-technical-details.md).
+For API implementation details, see [Backend Technical
+Details](./backend-technical-details.md).

--- a/docs/functional-presentation.md
+++ b/docs/functional-presentation.md
@@ -2,7 +2,10 @@
 
 ## Application Purpose
 
-INCAP is a collaborative blogging platform that allows a community to share knowledge and ideas through articles and discussions. It's designed to be a multidisciplinary knowledge-sharing platform where users can contribute content across various topics.
+INCAP is a collaborative blogging platform that allows a community to share
+knowledge and ideas through articles and discussions. It's designed to be a
+multidisciplinary knowledge-sharing platform where users can contribute content
+across various topics.
 
 ## Core Features
 
@@ -10,67 +13,60 @@ INCAP is a collaborative blogging platform that allows a community to share know
 
 **Capabilities:**
 
-- **Create Articles**: Authenticated users can create new articles with title and content
-- **Read Articles**: All visitors can browse and read published articles
-- **Update Articles**: Authors can modify their articles
-- **Delete Articles**: Authors can remove their articles
-- **Filter by Category**: Articles can be filtered by their assigned category
+- **Create Articles**: Authenticated users can create new articles with title
+  and content - **Read Articles**: All visitors can browse and read published
+  articles - **Update Articles**: Authors can modify their articles - **Delete
+  Articles**: Authors can remove their articles - **Filter by Category**:
+  Articles can be filtered by their assigned category
 
 **Key Attributes:**
 
-- Title
-- Content
-- Category assignment
-- Author identification
-- Timestamps (implicit)
+- Title - Content - Category assignment - Author identification - Timestamps
+  (implicit)
 
 ### 2. Category Management
 
 **Capabilities:**
 
-- **Create Categories**: Organize topics into logical categories
-- **List Categories**: Display all available categories
-- **Update Categories**: Modify category information
-- **Delete Categories**: Remove categories (with cascade rules)
+- **Create Categories**: Organize topics into logical categories - **List
+  Categories**: Display all available categories - **Update Categories**: Modify
+  category information - **Delete Categories**: Remove categories (with cascade
+  rules)
 
-**Purpose:**
-Categories serve as a taxonomy system to organize articles thematically, making content discovery intuitive.
+**Purpose:** Categories serve as a taxonomy system to organize articles
+thematically, making content discovery intuitive.
 
 ### 3. User Management
 
 **Capabilities:**
 
-- **User Registration**: New users can create accounts
-- **User Profiles**: Store user information and preferences
-- **User Authentication**: Framework for securing endpoints
-- **User Listing**: Administrative view of registered users
+- **User Registration**: New users can create accounts - **User Profiles**:
+  Store user information and preferences - **User Authentication**: Framework
+  for securing endpoints - **User Listing**: Administrative view of registered
+  users
 
 **User Attributes:**
 
-- Username/Email
-- User profile information
-- Role/permission framework
+- Username/Email - User profile information - Role/permission framework
 
 ### 4. Frontend Interface
 
 **Main Pages:**
 
-- **Home Page**: Landing page with featured content
-- **Articles Section**: Browse, search, and view articles
-- **Admin Panel**: Management interface for content and users
-- **Navigation**: Responsive navigation across all sections
+- **Home Page**: Landing page with featured content - **Articles Section**:
+  Browse, search, and view articles - **Admin Panel**: Management interface for
+  content and users - **Navigation**: Responsive navigation across all sections
 
 **User Experience:**
 
-- Responsive Bootstrap 5 design
-- Mobile-friendly interface
-- Intuitive navigation
-- Font Awesome icons for visual clarity
+- Responsive Bootstrap 5 design - Mobile-friendly interface - Intuitive
+  navigation - Font Awesome icons for visual clarity
 
 ## User Workflows
 
 ### Content Creator Workflow
-```
+
+```text
 1. User logs in/registers
 2. Navigates to Admin panel → Create Article
 3. Selects category and writes content
@@ -79,7 +75,8 @@ Categories serve as a taxonomy system to organize articles thematically, making 
 ```
 
 ### Content Consumer Workflow
-```
+
+```text
 1. User visits the site
 2. Browses articles on the home page
 3. Filters articles by category
@@ -88,7 +85,8 @@ Categories serve as a taxonomy system to organize articles thematically, making 
 ```
 
 ### Administrator Workflow
-```
+
+```text
 1. Admin logs in with elevated privileges
 2. Accesses the Admin panel
 3. Manages articles, categories, and users
@@ -98,26 +96,20 @@ Categories serve as a taxonomy system to organize articles thematically, making 
 
 ## Content Organization
 
-### Articles
+### Article Endpoints
 
-- Associated with a single category
-- Have an author
-- Contain title and content
-- Are timestamped
+- Associated with a single category - Have an author - Contain title and content
+  - Are timestamped
 
-### Categories
+### Category Endpoints
 
-- Have a unique name
-- Can contain multiple articles
-- Are editable and deletable
-- Drive the site's taxonomy
+- Have a unique name - Can contain multiple articles - Are editable and
+  deletable - Drive the site's taxonomy
 
-### Users
+### User Endpoints
 
-- Can be authors
-- Have profiles
-- May have different roles/permissions
-- Track activity and contributions
+- Can be authors - Have profiles - May have different roles/permissions - Track
+  activity and contributions
 
 ## API Endpoints
 
@@ -125,31 +117,25 @@ All endpoints are RESTful and follow standard HTTP methods:
 
 ### Articles
 
-- `GET /articles` - List articles (filterable by category)
-- `GET /articles/:id` - Get specific article
-- `POST /articles` - Create new article
-- `PUT /articles` - Update article
-- `DELETE /articles/:id` - Delete article
+- `GET /articles` - List articles (filterable by category) - `GET /articles/:id`
+  - Get specific article - `POST /articles` - Create new article - `PUT
+  /articles` - Update article - `DELETE /articles/:id` - Delete article
 
 ### Categories
 
-- `GET /categories` - List all categories
-- `GET /categories/:id` - Get specific category
-- `POST /categories` - Create new category
-- `PUT /categories` - Update category
-- `DELETE /categories/:id` - Delete category
+- `GET /categories` - List all categories - `GET /categories/:id` - Get specific
+  category - `POST /categories` - Create new category - `PUT /categories` -
+  Update category - `DELETE /categories/:id` - Delete category
 
 ### Users
 
-- `GET /users` - List all users
-- `GET /users/:id` - Get specific user
-- `POST /users` - Create new user
-- `PUT /users` - Update user
-- `DELETE /users/:id` - Delete user
+- `GET /users` - List all users - `GET /users/:id` - Get specific user - `POST
+  /users` - Create new user - `PUT /users` - Update user - `DELETE /users/:id` -
+  Delete user
 
 ## Data Model Overview
 
-```
+```text
 ┌─────────────────┐
 │    Category     │
 ├─────────────────┤
@@ -173,13 +159,13 @@ All endpoints are RESTful and follow standard HTTP methods:
 
 ## Security Considerations
 
-- API endpoints accept JSON payloads
-- CORS enabled for cross-origin requests
-- Environment-based configuration for sensitive data
-- JWT framework ready (in user management)
-- Rate limiting considerations for future
-- Input validation framework in place
+- API endpoints accept JSON payloads - CORS enabled for cross-origin requests -
+  Environment-based configuration for sensitive data - JWT framework ready (in
+  user management) - Rate limiting considerations for future - Input validation
+  framework in place
 
 ---
 
-For technical implementation details, see [Backend Technical Details](./backend-technical-details.md) and [Frontend Technical Details](./frontend-technical-details.md).
+For technical implementation details, see [Backend Technical
+Details](./backend-technical-details.md) and [Frontend Technical
+Details](./frontend-technical-details.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,45 +2,47 @@
 
 ## Overview
 
-**INCAP** is a modern MEAN stack web application built with TypeScript that recreates a collaborative blogging platform. Originally a PHP-based community website where members could post articles organized by categories with comments, INCAP serves as a comprehensive learning project exploring microservices architecture, containerization, and modern cloud-native development practices.
+**INCAP** is a modern MEAN stack web application built with TypeScript that
+recreates a collaborative blogging platform. Originally a PHP-based community
+website where members could post articles organized by categories with comments,
+INCAP serves as a comprehensive learning project exploring microservices
+architecture, containerization, and modern cloud-native development practices.
 
 ## Quick Facts
 
-- **Type**: Full-stack web application with microservices architecture
-- **Stack**: MEAN (MongoDB, Express, Angular, Node.js) + TypeScript
-- **UI Framework**: Angular 21 with Bootstrap 5
-- **Database**: MongoDB
-- **Container**: Docker & Docker Compose
-- **Orchestration**: Kubernetes-ready
-- **CI/CD**: AppVeyor with multi-stage pipeline
-- **Code Analysis**: SonarCloud, Snyk, Coveralls, Codacy
-- **Testing**: Vitest with comprehensive coverage
+- **Type**: Full-stack web application with microservices architecture -
+  **Stack**: MEAN (MongoDB, Express, Angular, Node.js) + TypeScript - **UI
+  Framework**: Angular 21 with Bootstrap 5 - **Database**: MongoDB -
+  **Container**: Docker & Docker Compose - **Orchestration**: Kubernetes-ready -
+  **CI/CD**: AppVeyor with multi-stage pipeline - **Code Analysis**: SonarCloud,
+  Snyk, Coveralls, Codacy - **Testing**: Vitest with comprehensive coverage
 
 ## Core Features
 
-- **Article Management**: Create, read, update, and delete articles
-- **Category Organization**: Organize articles into logical categories
-- **User Management**: User account management and authentication framework
-- **Responsive UI**: Modern Angular frontend with Bootstrap 5 styling
-- **REST API**: Well-structured Express.js backend APIs
+- **Article Management**: Create, read, update, and delete articles - **Category
+  Organization**: Organize articles into logical categories - **User
+  Management**: User account management and authentication framework -
+  **Responsive UI**: Modern Angular frontend with Bootstrap 5 styling - **REST
+  API**: Well-structured Express.js backend APIs
 
 ## Architecture Highlights
 
-- **Microservices Ready**: Modular backend structure with separate controllers, models, and route handlers
-- **Containerized**: Full Docker containerization for all services
-- **Type-Safe**: Complete TypeScript implementation across frontend and backend
-- **Cloud-Native**: Kubernetes deployment manifests included
-- **Quality-Focused**: Multiple quality gates and security scanning
+- **Microservices Ready**: Modular backend structure with separate controllers,
+  models, and route handlers - **Containerized**: Full Docker containerization
+  for all services - **Type-Safe**: Complete TypeScript implementation across
+  frontend and backend - **Cloud-Native**: Kubernetes deployment manifests
+  included - **Quality-Focused**: Multiple quality gates and security scanning
 
 ## Documentation Structure
 
-- [Functional Presentation](./functional-presentation.md) - Detailed feature overview
-- [Technical Overview](./technical-overview.md) - Architecture and technology stack
-- [Frontend Technical Details](./frontend-technical-details.md) - Angular implementation
-- [Backend Technical Details](./backend-technical-details.md) - Express.js and data layer
-- [CI/CD and Code Analysis](./cicd-and-analysis.md) - Pipeline and quality gates
-- [Deployment Guide](./deployment.md) - Docker, Compose, and Kubernetes
+- [Functional Presentation](./functional-presentation.md) - Detailed feature
+  overview - [Technical Overview](./technical-overview.md) - Architecture and
+  technology stack - [Frontend Technical
+  Details](./frontend-technical-details.md) - Angular implementation - [Backend
+  Technical Details](./backend-technical-details.md) - Express.js and data layer
+  - [CI/CD and Code Analysis](./cicd-and-analysis.md) - Pipeline and quality
+  gates - [Deployment Guide](./deployment.md) - Docker, Compose, and Kubernetes
 
 ---
 
-*Last updated: February 2026*
+Last updated: February 2026

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -2,15 +2,18 @@
 
 ## Nx Monorepo Migration
 
-This project is now managed as an Nx monorepo. All apps are under `apps/` and all builds, tests, and linting are run via Nx CLI. See [docs/nx-monorepo-migration.md](docs/nx-monorepo-migration.md) for details.
+This project is now managed as an Nx monorepo. All apps are under `apps/` and
+all builds, tests, and linting are run via Nx CLI. See
+[docs/nx-monorepo-migration.md](docs/nx-monorepo-migration.md) for details.
 
 ## Architecture Overview
 
-INCAP follows a modern, cloud-native architecture with clear separation between frontend and backend services.
+INCAP follows a modern, cloud-native architecture with clear separation between
+frontend and backend services.
 
 ### High-Level Architecture Diagram
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │                         Client Browser                          │
 └──────────────────────────────┬──────────────────────────────────┘
@@ -71,59 +74,100 @@ INCAP follows a modern, cloud-native architecture with clear separation between 
 ## Technology Stack
 
 ### Frontend Stack
+
 | Layer | Technology | Version | Purpose |
-|-------|-----------|---------|---------|
+
+| ------- | ----------- | --------- | --------- |
+
 | **Framework** | Angular | 21.1 | Component-based SPA framework |
+
 | **Language** | TypeScript | 5.9 | Type-safe JavaScript |
+
 | **UI Components** | ng-bootstrap | 20.0 | Angular Bootstrap components |
+
 | **Styling** | Bootstrap | 5.3 | Responsive CSS framework |
+
 | **Icons** | Font Awesome | 7.1 | Icon library |
+
 | **HTTP** | HttpClient | Built-in | REST API communication |
+
 | **Routing** | @angular/router | 21.1 | Client-side routing |
+
 | **Reactive** | RxJS | 7.8 | Reactive programming |
+
 | **Build Tool** | Angular CLI | 21.1 | Development & production builds |
 
 ### Backend Stack
+
 | Layer | Technology | Version | Purpose |
-|-------|-----------|---------|---------|
+
+| ------- | ----------- | --------- | --------- |
+
 | **Runtime** | Node.js | 24.x | JavaScript runtime |
+
 | **Framework** | Express.js | 5.2 | Web server framework |
+
 | **Language** | TypeScript | 5.9 | Type-safe JavaScript |
+
 | **Database** | MongoDB | Latest | NoSQL document database |
+
 | **ODM** | Mongoose | 9.1 | MongoDB object modeling |
+
 | **Logging** | Morgan | 1.10 | HTTP request logging |
+
 | **CORS** | cors | 2.8 | Cross-Origin Resource Sharing |
+
 | **Bundler** | esbuild | 0.27 | Fast JavaScript bundler |
+
 | **Body Parser** | body-parser | 2.2 | Request body parsing |
 
 ### Development & Testing Stack
+
 | Category | Technology | Version | Purpose |
-|----------|-----------|---------|---------|
+
+| ---------- | ----------- | --------- | --------- |
+
 | **Testing Framework** | Vitest | 4.0 | Fast unit test runner |
+
 | **Assertion** | Chai | 4.5 | BDD assertion library |
+
 | **Mocking** | Sinon | 21.0 | Spies, stubs, mocks |
+
 | **API Testing** | Supertest | 7.2 | HTTP assertion library |
+
 | **Code Coverage** | @vitest/coverage-v8 | 4.0 | V8 coverage provider |
+
 | **Linting** | ESLint | 9.39 | Code quality & style |
+
 | **Type Checking** | TypeScript | 5.9 | Static type analysis |
 
 ### Infrastructure & DevOps
+
 | Component | Technology | Purpose |
-|-----------|-----------|---------|
+
+| ----------- | ----------- | --------- |
+
 | **Containerization** | Docker | Container images for all services |
+
 | **Orchestration** | Docker Compose | Local development environment |
+
 | **Kubernetes** | K8s YAML manifests | Production orchestration |
+
 | **CI/CD** | AppVeyor | Build and test automation |
+
 | **Code Analysis** | SonarCloud | Code quality analysis |
+
 | **Security Scanning** | Snyk | Vulnerability detection |
+
 | **Coverage Tracking** | Coveralls | Code coverage reporting |
+
 | **Code Review** | Codacy | Automated code review |
 
 ## Service Architecture
 
 ### Service Decomposition
 
-```
+```text
 ┌─────────────────────────────────────────────────────────┐
 │                   Backend (Port 4000)                   │
 ├─────────────────┬─────────────────┬─────────────────────┤
@@ -141,29 +185,26 @@ INCAP follows a modern, cloud-native architecture with clear separation between 
 
 ### Three-Layer Backend Architecture
 
-**1. Route Layer**
+#### 1. Route Layer
 
-- Defines HTTP endpoints
-- Handles request routing
-- Uses `express-async-handler` for async/await support
-- Decouples HTTP concerns from business logic
+- Defines HTTP endpoints - Handles request routing - Uses
+  `express-async-handler` for async/await support - Decouples HTTP concerns from
+  business logic
 
-**2. Controller Layer**
+#### 2. Controller Layer
 
-- Processes incoming requests
-- Orchestrates business logic via Process layer
-- Handles parameter extraction
-- Returns formatted JSON responses
+- Processes incoming requests - Orchestrates business logic via Process layer -
+  Handles parameter extraction - Returns formatted JSON responses
 
-**3. Service Layers**
+#### 3. Service Layers
 
-- **Process Layer**: Business logic and data manipulation
-- **Model Layer**: Data schemas, validation, and persistence
-- Mongoose models provide MongoDB integration
+- **Process Layer**: Business logic and data manipulation - **Model Layer**:
+  Data schemas, validation, and persistence - Mongoose models provide MongoDB
+  integration
 
 ### Data Flow
 
-```
+```text
 HTTP Request
     ↓
 Routes (article.routes.ts)
@@ -183,7 +224,7 @@ Response (JSON)
 
 ### Module Structure
 
-```
+```text
 src/app/
 ├── app.component        # Root component
 ├── app.module          # Root module declaration
@@ -200,7 +241,7 @@ src/app/
 
 ### Component Hierarchy
 
-```
+```text
 AppComponent (Root)
 ├── AppRoutingModule
 │   ├── Route: '' → AppComponent
@@ -214,7 +255,8 @@ AppComponent (Root)
 ## Deployment Architecture
 
 ### Development Environment
-```
+
+```text
 Docker Compose:
 - Frontend (localhost:8080)
 - Backend (localhost:4000)
@@ -222,7 +264,8 @@ Docker Compose:
 ```
 
 ### Production Environment
-```
+
+```text
 Kubernetes:
 - Frontend Deployment + Service
 - Backend Deployment + Service
@@ -235,23 +278,18 @@ Kubernetes:
 
 ### Frontend-Backend Communication
 
-- **Protocol**: HTTP/REST
-- **Data Format**: JSON
-- **Configuration**: Dynamic via `settings.json`
-- **API URLs**:
-  - Categories: `/categories`
-  - Users: `/users`
-  - Articles: `/articles`
+- **Protocol**: HTTP/REST - **Data Format**: JSON - **Configuration**: Dynamic
+  via `settings.json` - **API URLs**: - Categories: `/categories` - Users:
+  `/users` - Articles: `/articles`
 
 ### Backend-Database Communication
 
-- **Protocol**: MongoDB Wire Protocol
-- **ODM**: Mongoose for abstraction
-- **Connection**: Configurable via `MONGO_DB_URL` environment variable
+- **Protocol**: MongoDB Wire Protocol - **ODM**: Mongoose for abstraction -
+  **Connection**: Configurable via `MONGO_DB_URL` environment variable
 
 ## Development Workflow
 
-```
+```text
                      Feature Development
                             ↓
                     Git Branch (feature/*)
@@ -283,16 +321,16 @@ Kubernetes:
 
 ## Key Design Patterns
 
-1. **Controller-Service-Repository Pattern**: Clear separation of concerns
-2. **Dependency Injection**: Implicit in constructor parameters
-3. **Lazy Loading**: Angular feature modules loaded on demand
-4. **Reactive Programming**: RxJS observables for async operations
-5. **Type Safety**: Full TypeScript implementation
-6. **Environment Configuration**: Settings via environment variables
+1. **Controller-Service-Repository Pattern**: Clear separation of concerns 2.
+   **Dependency Injection**: Implicit in constructor parameters 3. **Lazy
+   Loading**: Angular feature modules loaded on demand 4. **Reactive
+   Programming**: RxJS observables for async operations 5. **Type Safety**: Full
+   TypeScript implementation 6. **Environment Configuration**: Settings via
+   environment variables
 
 ---
 
 For detailed implementation specifics, see:
 
-- [Frontend Technical Details](./frontend-technical-details.md)
-- [Backend Technical Details](./backend-technical-details.md)
+- [Frontend Technical Details](./frontend-technical-details.md) - [Backend
+  Technical Details](./backend-technical-details.md)


### PR DESCRIPTION
## Summary
- add the missing comments frontend API configuration and route comment update/delete calls through the configured API URLs
- keep the split per-endpoint nginx environment variables and point Docker/Kubernetes frontend routing at the backend service DNS name instead of localhost
- modernize the Kubernetes manifests with `apps/v1` deployments, selectors, basic probes, and internal-only backend/database services
- clean up repository documentation to satisfy Codacy Markdown rules for line length, heading spacing, fenced block spacing, and fenced block language tags

## What changed
- added `commentsApiUrl` to frontend runtime settings and `/api/comments` to `settings.json`
- updated `CommentService` so all comment requests go through configured API endpoints
- restored separate nginx proxy targets for categories, users, articles, and comments
- updated frontend Docker and compose/Kubernetes manifests to inject:
  - `CATEGORIES_API_URL`
  - `USERS_API_URL`
  - `ARTICLES_API_URL`
  - `COMMENTS_API_URL`
- switched Kubernetes `Deployment` manifests from `extensions/v1beta1` to `apps/v1` and added required selectors
- added readiness/liveness probes for frontend, backend, and MongoDB
- changed backend and MongoDB services to `ClusterIP` while keeping the frontend service exposed
- updated the root and deploy compose files plus `docs/deployment.md` to match the new runtime wiring
- reformatted Markdown across the repository docs to satisfy Codacy and markdownlint
  - wrapped long lines
  - added blank lines around headings and fenced code blocks
  - added languages to fenced code blocks
  - cleaned up a few README/document structure issues

## Verification
- `npm run test:frontend`
- `npm run build:frontend`
- `npx markdownlint-cli2 "**/*.md" "#node_modules"`
- reviewed updated Kubernetes YAML and deployment documentation for consistency